### PR TITLE
CI: test_settings environ fix

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -16,4 +16,4 @@ DATABASES = {
     }
 }
 
-GLOBEE_AUTH_KEY = os.environ['GLOBEE_AUTH_KEY']
+GLOBEE_AUTH_KEY = os.environ.get('GLOBEE_AUTH_KEY')


### PR DESCRIPTION
call environ.get() instead of trying to access the dict key